### PR TITLE
#9 - feat: 판매 내역 페이지 구현 중

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^2.9.11",
         "@reduxjs/toolkit": "^1.9.2",
-        "@tanstack/react-query": "^4.24.10",
+        "@tanstack/react-query": "^4.29.5",
         "@tanstack/react-query-devtools": "^4.24.12",
         "axios": "^1.2.6",
         "react": "^18.2.0",
@@ -751,20 +751,20 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.24.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.24.10.tgz",
-      "integrity": "sha512-2QywqXEAGBIUoTdgn1lAB4/C8QEqwXHj2jrCLeYTk2xVGtLiPEUD8jcMoeB2noclbiW2mMt4+Fq7fZStuz3wAQ==",
+      "version": "4.29.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.5.tgz",
+      "integrity": "sha512-xXIiyQ/4r9KfaJ3k6kejqcaqFXXBTzN2aOJ5H1J6aTJE9hl/nbgAdfF6oiIu0CD5xowejJEJ6bBg8TO7BN4NuQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.24.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.24.10.tgz",
-      "integrity": "sha512-FY1DixytOcNNCydPQXLxuKEV7VSST32CAuJ55BjhDNqASnMLZn+6c30yQBMrODjmWMNwzfjMZnq0Vw7C62Fwow==",
+      "version": "4.29.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.5.tgz",
+      "integrity": "sha512-F87cibC3s3eG0Q90g2O+hqntpCrudKFnR8P24qkH9uccEhXErnJxBC/AAI4cJRV2bfMO8IeGZQYf3WyYgmSg0w==",
       "dependencies": {
-        "@tanstack/query-core": "4.24.10",
+        "@tanstack/query-core": "4.29.5",
         "use-sync-external-store": "^1.2.0"
       },
       "funding": {
@@ -5393,16 +5393,16 @@
       }
     },
     "@tanstack/query-core": {
-      "version": "4.24.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.24.10.tgz",
-      "integrity": "sha512-2QywqXEAGBIUoTdgn1lAB4/C8QEqwXHj2jrCLeYTk2xVGtLiPEUD8jcMoeB2noclbiW2mMt4+Fq7fZStuz3wAQ=="
+      "version": "4.29.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.5.tgz",
+      "integrity": "sha512-xXIiyQ/4r9KfaJ3k6kejqcaqFXXBTzN2aOJ5H1J6aTJE9hl/nbgAdfF6oiIu0CD5xowejJEJ6bBg8TO7BN4NuQ=="
     },
     "@tanstack/react-query": {
-      "version": "4.24.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.24.10.tgz",
-      "integrity": "sha512-FY1DixytOcNNCydPQXLxuKEV7VSST32CAuJ55BjhDNqASnMLZn+6c30yQBMrODjmWMNwzfjMZnq0Vw7C62Fwow==",
+      "version": "4.29.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.5.tgz",
+      "integrity": "sha512-F87cibC3s3eG0Q90g2O+hqntpCrudKFnR8P24qkH9uccEhXErnJxBC/AAI4cJRV2bfMO8IeGZQYf3WyYgmSg0w==",
       "requires": {
-        "@tanstack/query-core": "4.24.10",
+        "@tanstack/query-core": "4.29.5",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^2.9.11",
     "@reduxjs/toolkit": "^1.9.2",
-    "@tanstack/react-query": "^4.24.10",
+    "@tanstack/react-query": "^4.29.5",
     "@tanstack/react-query-devtools": "^4.24.12",
     "axios": "^1.2.6",
     "react": "^18.2.0",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -6,6 +6,8 @@ import ProductList from "@pages/ProductsList";
 import SignUp from "@pages/SignUp";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import SalesList from "@pages/SalesList";
+import { Suspense } from "react";
+import Spinner from "@components/Spinner";
 
 const Router = () => {
   return (
@@ -13,11 +15,27 @@ const Router = () => {
       <Routes>
         <Route index path="/signin" element={<SignIn />} />
         <Route path="/signup" element={<SignUp />} />
+
         <Route element={<Layout />}>
-          <Route path="/" index element={<ProductList />} />
+          <Route
+            path="/"
+            index
+            element={
+              <Suspense fallback={<Spinner />}>
+                <ProductList />
+              </Suspense>
+            }
+          />
           <Route path="product" index element={<Product />} />
           <Route path="product/:id" index element={<ProductDetail />} />
-          <Route path="sales/detail" index element={<SalesList />} />
+          <Route
+            path="sales/detail"
+            element={
+              <Suspense fallback={<Spinner />}>
+                <SalesList />
+              </Suspense>
+            }
+          />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,6 +5,7 @@ import ProductDetail from "@pages/ProductDetail";
 import ProductList from "@pages/ProductsList";
 import SignUp from "@pages/SignUp";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import SalesList from "@pages/SalesList";
 
 const Router = () => {
   return (
@@ -16,6 +17,7 @@ const Router = () => {
           <Route path="/" index element={<ProductList />} />
           <Route path="product" index element={<Product />} />
           <Route path="product/:id" index element={<ProductDetail />} />
+          <Route path="sales/detail" index element={<SalesList />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -39,7 +39,7 @@ export const getProduct = async (id: string) => {
   return data;
 };
 // 거래 내역 조회
-interface TransactionDetail {
+export interface TransactionDetail {
   // 거래 내역 정보
   detailId: string; // 거래 내역 ID
   user: {
@@ -147,5 +147,14 @@ export const deleteProduct = async (id: string) => {
     url: `/products/${id}`,
   });
 
+  return res;
+};
+
+// 전체 거래(판매) 내역
+export const getSalesList = async () => {
+  const res = await client({
+    method: "GET",
+    url: "/products/transactions/all",
+  });
   return res;
 };

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,13 @@
+const Spinner = () => {
+  return (
+    <div
+      className="m-auto h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-r-transparent align-[-0.125em] text-rose-200 motion-reduce:animate-[spin_1.5s_linear_infinite]"
+      role="status"
+    >
+      <span className="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]">
+        Loading...
+      </span>
+    </div>
+  );
+};
+export default Spinner;

--- a/src/lib/hooks/useGetSalesListQuery.ts
+++ b/src/lib/hooks/useGetSalesListQuery.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSalesList } from "api";
+import React from "react";
+
+const useGetSalesListQuery = () => {
+  const { data: salesList } = useQuery({
+    queryKey: ["salesList"],
+    queryFn: getSalesList,
+  });
+
+  return { salesList };
+};
+
+export default useGetSalesListQuery;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import "./index.css";
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      suspense: true,
       refetchOnWindowFocus: false,
     },
   },

--- a/src/pages/SalesList/index.tsx
+++ b/src/pages/SalesList/index.tsx
@@ -1,0 +1,45 @@
+import type { TransactionDetail } from "api";
+import useGetSalesListQuery from "lib/hooks/useGetSalesListQuery";
+
+const SalesList = () => {
+  const { salesList } = useGetSalesListQuery();
+  console.log(salesList?.data);
+  return (
+    <div>
+      <h4 className="border-b-2 pb-3 text-xl font-semibold">판매 내역</h4>
+      <ul className="mt-4">
+        {salesList?.data.map((item: TransactionDetail) => (
+          <li
+            key={item.timePaid}
+            className="mb-3 flex justify-between border-2 px-3 py-4"
+          >
+            <div className="flex gap-5">
+              <div className="w-40">
+                <img src={item.product.thumbnail!} alt={item.product.title} />
+              </div>
+              <div>
+                <p className="text-bold font-semibold">{item.product.title}</p>
+                <p className="text-sm text-slate-500">
+                  {new Date(item.timePaid).toLocaleDateString()} 결제
+                </p>
+                <p>금액 {item.product.price.toLocaleString()}원</p>
+                <p>결제 수단 {item.account.bankName}</p>
+                <p>취소 여부 {item.isCanceled ? "o" : "x"}</p>
+                <p>확정 여부 {item.done ? "o" : "x"}</p>
+              </div>
+            </div>
+            <div className="flex flex-col justify-center">
+              {!item.isCanceled && !item.done ? (
+                <button type="button" className="cursor-pointer border p-3">
+                  거래 취소
+                </button>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SalesList;


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

- #9 

## 작업 내용 (변경 사항)

- 판매 내역 페이지를 생성하고 기본적인 구조를 잡았습니다.
- react-query로 판매 내역 데이터를 불러옵니다.
- 로딩 스피너를 추가했습니다.

## 리뷰 요청 사항
- 홈에도 스피너를 추가해주지 않으면 새로고침해야 데이터를 불러올 수 있어서 추가했습니다. 만약 문제가 된다면 말씀해주세요..!

##  SAMPLE
![스크린샷 2023-04-27 오후 10 30 35](https://user-images.githubusercontent.com/103406196/234877360-36560cad-176a-4480-940f-c8af29a1a783.png)
