### PR TITLE
#9 - 거래 내역 페이지 기능 구현

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -158,3 +158,23 @@ export const getSalesList = async () => {
   });
   return res;
 };
+
+interface RequsetBody {
+  isCanceled?: boolean; // 거래 취소 여부 (사용자의 '제품 거래(구매) 취소' 상태와 같습니다)
+  done?: boolean; // 거래 완료 여부 (사용자의 '제품 거래(구매) 확정' 상태와 같습니다)
+}
+
+// 거래(판매) 내역 완료/취소 및 해제
+export const changeSalesStatus = async (
+  id: string,
+  isCanceled?: boolean,
+  done?: boolean,
+) => {
+  const res = await client({
+    method: "PUT",
+    url: `/products/transactions/${id}`,
+    data: { isCanceled, done },
+  });
+  console.log(res);
+  return res;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -156,7 +156,7 @@ export const getSalesList = async () => {
     method: "GET",
     url: "/products/transactions/all",
   });
-  return res;
+  return res.data;
 };
 
 interface RequsetBody {

--- a/src/lib/hooks/useChangeStatusMutate.ts
+++ b/src/lib/hooks/useChangeStatusMutate.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { changeSalesStatus } from "api";
+import React from "react";
+
+const useChangeStatusMutate = () => {
+  const queryClient = useQueryClient();
+  const { mutate: changeStatusMutate } = useMutation(
+    (id: string) => changeSalesStatus(id, true, true),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries();
+      },
+    },
+  );
+  return { changeStatusMutate };
+};
+
+export default useChangeStatusMutate;

--- a/src/lib/hooks/useGetSalesListQuery.ts
+++ b/src/lib/hooks/useGetSalesListQuery.ts
@@ -1,11 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { getSalesList } from "api";
-import React from "react";
+import type { TransactionDetail } from "api";
 
 const useGetSalesListQuery = () => {
   const { data: salesList } = useQuery({
     queryKey: ["salesList"],
     queryFn: getSalesList,
+    select: (data) =>
+      data.sort(
+        (a: TransactionDetail, b: TransactionDetail) =>
+          new Date(b.timePaid).getDate() - new Date(a.timePaid).getDate(),
+      ),
   });
 
   return { salesList };

--- a/src/pages/SalesList/index.tsx
+++ b/src/pages/SalesList/index.tsx
@@ -1,5 +1,4 @@
 import type { TransactionDetail } from "api";
-import { changeSalesStatus } from "api";
 import useChangeStatusMutate from "lib/hooks/useChangeStatusMutate";
 import useGetSalesListQuery from "lib/hooks/useGetSalesListQuery";
 
@@ -11,7 +10,7 @@ const SalesList = () => {
     <div>
       <h4 className="border-b-2 pb-3 text-xl font-semibold">판매 내역</h4>
       <ul className="mt-4">
-        {salesList?.data.map((item: TransactionDetail) => (
+        {salesList.map((item: TransactionDetail) => (
           <li
             key={item.timePaid}
             className="mb-3 flex justify-between border-2 px-3 py-4"

--- a/src/pages/SalesList/index.tsx
+++ b/src/pages/SalesList/index.tsx
@@ -1,9 +1,12 @@
 import type { TransactionDetail } from "api";
+import { changeSalesStatus } from "api";
+import useChangeStatusMutate from "lib/hooks/useChangeStatusMutate";
 import useGetSalesListQuery from "lib/hooks/useGetSalesListQuery";
 
 const SalesList = () => {
   const { salesList } = useGetSalesListQuery();
-  console.log(salesList?.data);
+  const { changeStatusMutate } = useChangeStatusMutate();
+
   return (
     <div>
       <h4 className="border-b-2 pb-3 text-xl font-semibold">판매 내역</h4>
@@ -30,7 +33,11 @@ const SalesList = () => {
             </div>
             <div className="flex flex-col justify-center">
               {!item.isCanceled && !item.done ? (
-                <button type="button" className="cursor-pointer border p-3">
+                <button
+                  type="button"
+                  className="cursor-pointer border p-3"
+                  onClick={() => changeStatusMutate(item.detailId)}
+                >
                   거래 취소
                 </button>
               ) : null}

--- a/src/pages/SalesList/index.tsx
+++ b/src/pages/SalesList/index.tsx
@@ -1,49 +1,80 @@
 import type { TransactionDetail } from "api";
 import useChangeStatusMutate from "lib/hooks/useChangeStatusMutate";
 import useGetSalesListQuery from "lib/hooks/useGetSalesListQuery";
+import usePagination from "lib/hooks/usePagination";
 
 const SalesList = () => {
   const { salesList } = useGetSalesListQuery();
   const { changeStatusMutate } = useChangeStatusMutate();
+  const { totalPage, offset, limit, handleClick, page } =
+    usePagination(salesList);
 
   return (
     <div>
       <h4 className="border-b-2 pb-3 text-xl font-semibold">판매 내역</h4>
       <ul className="mt-4">
-        {salesList.map((item: TransactionDetail) => (
-          <li
-            key={item.timePaid}
-            className="mb-3 flex justify-between border-2 px-3 py-4"
-          >
-            <div className="flex gap-5">
-              <div className="w-40">
-                <img src={item.product.thumbnail!} alt={item.product.title} />
+        {salesList
+          .slice(offset, offset + limit)
+          .map((item: TransactionDetail) => (
+            <li
+              key={item.timePaid}
+              className="mb-3 flex justify-between border-2 px-3 py-4"
+            >
+              <div className="flex gap-5">
+                <div className="w-40">
+                  <img src={item.product.thumbnail!} alt={item.product.title} />
+                </div>
+                <div>
+                  <p className="text-bold font-semibold">
+                    {item.product.title}
+                  </p>
+                  <p className="text-sm text-slate-500">
+                    {new Date(item.timePaid).toLocaleDateString()} 결제
+                  </p>
+                  <p>금액 {item.product.price.toLocaleString()}원</p>
+                  <p>결제 수단 {item.account.bankName}</p>
+                  <p>취소 여부 {item.isCanceled ? "o" : "x"}</p>
+                  <p>확정 여부 {item.done ? "o" : "x"}</p>
+                </div>
               </div>
-              <div>
-                <p className="text-bold font-semibold">{item.product.title}</p>
-                <p className="text-sm text-slate-500">
-                  {new Date(item.timePaid).toLocaleDateString()} 결제
-                </p>
-                <p>금액 {item.product.price.toLocaleString()}원</p>
-                <p>결제 수단 {item.account.bankName}</p>
-                <p>취소 여부 {item.isCanceled ? "o" : "x"}</p>
-                <p>확정 여부 {item.done ? "o" : "x"}</p>
+              <div className="flex flex-col justify-center">
+                {!item.isCanceled && !item.done ? (
+                  <button
+                    type="button"
+                    className="cursor-pointer border p-3"
+                    onClick={() => changeStatusMutate(item.detailId)}
+                  >
+                    거래 취소
+                  </button>
+                ) : null}
               </div>
-            </div>
-            <div className="flex flex-col justify-center">
-              {!item.isCanceled && !item.done ? (
-                <button
-                  type="button"
-                  className="cursor-pointer border p-3"
-                  onClick={() => changeStatusMutate(item.detailId)}
-                >
-                  거래 취소
-                </button>
-              ) : null}
-            </div>
-          </li>
-        ))}
+            </li>
+          ))}
       </ul>
+      <div className="flex items-center justify-center gap-4 pt-4">
+        <button
+          type="button"
+          disabled={page === `1`}
+          onClick={() => handleClick(Number(page) - 1)}
+        >
+          prev
+        </button>
+        {Array(totalPage)
+          .fill(null)
+          .map((_, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <button type="button" key={i} onClick={() => handleClick(i + 1)}>
+              {i + 1}
+            </button>
+          ))}
+        <button
+          type="button"
+          disabled={page >= `${totalPage}`}
+          onClick={() => handleClick(Number(page) + 1)}
+        >
+          next
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

- #9

## 작업 내용 (변경 사항)

- mutate 함수를 사용하여 거래 취소를 가능하게 하였습니다.
- 최신 순으로 거래 내역을 불러오게 하였습니다.
- 거래 내역을 10개씩 나누어 페이지를 보여줍니다.

## 리뷰 요청 사항

- 
